### PR TITLE
Create new event objects for dispatch

### DIFF
--- a/lib/touchy.js
+++ b/lib/touchy.js
@@ -35,38 +35,19 @@ module.exports = touchy;
         move: 'MSPointerMove',
         end: 'MSPointerUp'
       },
-      evts = isTouch ? touchEvents : setEventType(),
-      customEvents = {
-        tap: '',
-        doubleTap: '',
-        twoFingerTap: '',
-        longTouch: '',
-        swipeleft: '',
-        swiperight: '',
-        swipeup: '',
-        swipedown: ''
-      },
-      swipeEvents = ['tap', 'doubleTap', 'twoFingerTap', 'longTouch', 'swipeleft', 'swiperight', 'swipeup', 'swipedown'];
+      evts = isTouch ? touchEvents : setEventType();
 
   // If this is not Webkit touch, is it a MS Pointer or a regular mouse device?
   function setEventType () {
     return window.navigator.msPointerEnabled ? msPointerEvents : mouseEvents;
   }
-  
-  // Create the custom events to be dispatched
-  function createSwipeEvents () {
-    swipeEvents.forEach(function(evt) {
-      customEvents[evt] = d.createEvent('UIEvents');
-      customEvents[evt].initEvent(evt, true, true);
-    });
-  }
 
-  // Fix for stopPropagation. It's not working in Webkit and Opera for custom events
-  function stopBubbling (event) {
-    event.cancelBubble = true;
-    setTimeout(function() {
-      event.cancelBubble = false;
-    },0);
+  // Dispatch new event
+  function dispatchEvent (target, event) {
+    var evt = d.createEvent('UIEvents');
+
+    evt.initEvent(event, true, true);
+    target.dispatchEvent(evt);
   }
 
   function onStart (event) {
@@ -81,7 +62,7 @@ module.exports = touchy;
 
     d.addEventListener(evts.move, onMove, false);
     d.addEventListener(evts.end, onEnd, false);
-    
+
     function onMove (e) {
       hasMoved = true;
       nrOfFingers = isTouch ? e.touches.length : 1;
@@ -99,16 +80,16 @@ module.exports = touchy;
         if (!hasMoved) {
           if (timeDiff <= 500) {
             if (doubleTap) {
-              ele.dispatchEvent(customEvents.doubleTap);
+              dispatchEvent(ele, 'doubleTap');
             }
             else {
-              ele.dispatchEvent(customEvents.tap);
+              dispatchEvent(ele, 'tap');
               doubleTap = true;
             }
             resetDoubleTap();
           }
           else {
-            ele.dispatchEvent(customEvents.longTouch);
+            dispatchEvent(ele, 'longTouch');
           }
         }
         else {
@@ -121,38 +102,36 @@ module.exports = touchy;
             dirY = diffY > 0 ? 'down' : 'up';
             absDiffX = Math.abs(diffX);
             absDiffY = Math.abs(diffY);
-            
+
             if (absDiffX >= absDiffY) {
               customEvent = 'swipe' + dirX;
             }
             else {
               customEvent = 'swipe' + dirY;
             }
-            
-            ele.dispatchEvent(customEvents[customEvent]);
+
+            dispatchEvent(ele, customEvent);
           }
         }
       }
       else if (nrOfFingers === 2) {
-        ele.dispatchEvent(customEvents.twoFingerTap);
+        dispatchEvent(ele, 'twoFingerTap');
       }
 
       d.removeEventListener(evts.move, onMove, false);
       d.removeEventListener(evts.end, onEnd, false);
     }
   }
-  
+
   function resetDoubleTap() {
     setTimeout(function() {doubleTap = false;}, 400);
   }
-  
 
-  createSwipeEvents();
+
   d.addEventListener(evts.start, onStart, false);
 
   // Return an object to access useful properties and methods
   touchy = {
     isTouch: isTouch,
-    stop: stopBubbling,
     events: evts
   }


### PR DESCRIPTION
According to W3C recommendation, all events dispatches with new objects. It allows you to use `stopPropagation` instead of `touchy.stop`-hack.
