### PR TITLE
module.exports needs to be defined after touchy object

### DIFF
--- a/src/touchy.js
+++ b/src/touchy.js
@@ -12,8 +12,6 @@
  * @license    MIT
  */
 
-module.exports = touchy;
-
   var d = document,
       touchy,
       isTouch = 'ontouchstart' in window,
@@ -160,8 +158,8 @@ module.exports = touchy;
   d.addEventListener(evts.start, onStart, false);
 
   // Return an object to access useful properties and methods
-  touchy = {
+  module.exports = touchy = {
     isTouch: isTouch,
     stop: stopBubbling,
     events: evts
-  }
+  };


### PR DESCRIPTION
When I've tried to use dist/touchy.js I got `undefined` in `window.touchy`.
